### PR TITLE
Added Gulp-Data plugin to replace jsoncombine

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,10 +18,11 @@
   },
   "dependencies": {
     "browser-sync": "^2.10.0",
+    "glob": "^6.0.4",
     "gulp": "^3.9.0",
     "gulp-concat": "^2.6.0",
+    "gulp-data": "^1.2.1",
     "gulp-foreach": "^0.1.0",
-    "gulp-jsoncombine": "^1.0.3",
     "gulp-less": "^3.0.5",
     "gulp-minify-css": "^1.2.1",
     "gulp-plumber": "^1.0.1",

--- a/src/data/page.json
+++ b/src/data/page.json
@@ -1,0 +1,3 @@
+{
+    "greeting" : "Hola"
+}

--- a/src/templates/urls/index.html
+++ b/src/templates/urls/index.html
@@ -2,5 +2,5 @@
 
 {% block bodytag %}
 	<h1>{{ settings.siteName }}</h1>
-	<p>Hello {{ 'world' }}!</p>
+	<p>{{ page.greeting }} {{ 'world' }}!</p>
 {% endblock %}


### PR DESCRIPTION
I replaced jsoncombine with gulp-data plugin which most gulp template engines use to inject data with now. This decouples data as a separate function from twig itself. Also, because of this I was able to remove the jsoncombine task, which was depended on by the twig task.
