### PR TITLE
switch a fork of gulp-twig with latest twigjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "gulp-less": "^3.0.5",
     "gulp-plumber": "^1.0.1",
     "gulp-rename": "^1.2.2",
-    "gulp-twig": "^0.5.0",
+    "gulp-twig": "olets/gulp-twig.git#update-dependencies",
     "gulp-uglify": "^1.5.1"
   }
 }


### PR DESCRIPTION
This shifts the gulp-twig dependency to a fork of gulp-twig that's using the latest release of twigjs
